### PR TITLE
fix(spotify): fixes #12 adding too many tracks into a playlist exceeds maxiumum

### DIFF
--- a/src/api/spotifyApi.js
+++ b/src/api/spotifyApi.js
@@ -159,13 +159,24 @@ export default class SpotifyApi {
     }
 
     async addItemsToPlaylist(playlist_id, uris) {
-        let request = { uris: uris };
-        return await fetch(`${this.base_uri}/playlists/${playlist_id}/tracks`, {
-            method: "POST",
-            headers: this.headers,
+        const tmp = [...uris];
+        let tracks = [];
 
-            body: JSON.stringify(request),
-        }).then((res) => res.json());
+        while (tmp.length) {
+            const newUris = tmp.splice(0, 100);
+            let request = { uris: newUris };
+            const newTracks = await fetch(
+                `${this.base_uri}/playlists/${playlist_id}/tracks`,
+                {
+                  method: "POST",
+                  headers: this.headers,
+
+                  body: JSON.stringify(request),
+                }
+            ).then((res) => res.json());
+            tracks = tracks.concat(newTracks);
+        }
+        return tracks;
     }
 
     async getAvailableMarkets() {


### PR DESCRIPTION
… allowed items in one request

This PR splits all tracks into small chunks by 100 items each and send them batch by batch

This addresses: https://github.com/jlnbxn/TrackMatch/issues/12